### PR TITLE
Re-align layout on Streamer Style

### DIFF
--- a/lichess.streamer.user.css
+++ b/lichess.streamer.user.css
@@ -124,6 +124,21 @@ body.dark { background: #161512; }
   .ruser a {
     flex: none;
   }
+
+  /* Move puzzle board down to match main game board (ornicar/userstyles#4) */
+  main.puzzle {
+    margin-top: calc(30px - 0.5em);
+  }
+
+  /* Horizontally align board between different views (game vs puzzle) */
+  cg-container {
+    right: auto;
+    left: 0px;
+  }
+
+  .analyse__player_strip, .rclock {
+    margin-right: calc(100% - var(--cg-width));
+  }
 }
 
 #top .site-buttons a[title="Moderation"] {

--- a/lichess.streamer.user.css
+++ b/lichess.streamer.user.css
@@ -2,12 +2,86 @@
 @name           Lichess Streamer Layout
 @namespace      github.com/ornicar/userstyles
 @homepageURL    https://raw.githubusercontent.com/ornicar/userstyles/master/lichess.streamer.user.css
-@version        1.1.0
+@version        1.1.2
 @description    On lichess.org games, puts usernames and clocks around board for easier screen capture
 @author         github.com/ornicar
 ==/UserStyle== */
 
 @-moz-document domain("lichess.org") {
+/* Change background to fixed color to allow blending into custom stream overlays */
+body { background: #EDEBE9; }
+body.dark { background: #161512; }
+
+/* Display board above clock drop shadows*/
+.round__app__board {
+  z-index: 2;
+}
+
+/* Adjustments to wide layout */
+@media (min-width: 1260px) {
+  /* Hide scrollbar and make board larger */
+  body.playing {
+    /* TODO: Might need to add extra adjustments for small v-heights */
+    height: 100vh;
+    overflow: hidden !important;
+
+    /* Remove 2vmin bottom margin */
+    margin: 0px;
+    padding: 0px;
+    --zoom: 95 !important;
+  }
+
+  /* Make clocks bigger */
+  .rclock .time {
+    /*
+     * TODO: needs !important because of setting later on
+     * This should be refactored at some point when the narrower
+     * layout gets updates
+     */
+    line-height: 40px !important;
+    height: 40px;
+    min-width: 9rem;
+    justify-content: center;
+    padding: 0px 1rem;
+  }
+
+  /*
+   * Re-align the top "more time" plus button
+   * to vertically center on expanded clock
+   */
+  .rclock-top .time, .rclock-top a.moretime {
+    margin-top: -10px;
+  }
+
+  /* Layout to re-align board */
+  .round {
+    --chat-top-margin: calc(30px - 0.5rem);
+    grid-template-areas: "side app app" "uchat app app";
+    grid-template-rows: calc(var(--chat-top-margin) + var(--cg-height)) 30px;
+    grid-row-gap: 0;
+  }
+
+  /* Remove underboard scoresheet */
+  .round__underboard {
+    display: none;
+  }
+
+  /* Re-align left sidebar to top of board */
+  .round__side {
+    margin-top: var(--chat-top-margin);
+  }
+
+  /* Vertically center list of spectators underneath chat */
+  .round__underchat {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .chat__members {
+    height: auto !important;
+  }
+}
 
 @media (min-width: 800px), (orientation: landscape) {
   .round__app {


### PR DESCRIPTION
### Fixes / Changes: 
 - Expands board to cover more of the screen (useful for smaller windows) - see below for full comparison
 - Removes gradient at the top of the page (useful for integrating into OBS overlays / chroma-keying)
 - Positions board on top of clocks' drop shadows
   ![image](https://user-images.githubusercontent.com/974758/218641535-510468ec-5eca-45af-981d-a7d132d1ac21.png)
 - Adds extra vertical padding to clocks for visual appeal
   ![image](https://user-images.githubusercontent.com/974758/218641189-f8a2f18e-6235-427d-a569-c654a7dd2927.png)
 - Re-aligns board and chat boxes
   ![image](https://user-images.githubusercontent.com/974758/218641342-546d41e3-e2ea-4251-a2af-0b864cb5ca69.png)
 - Fixes vertical scroll issues
 - Fixes #4 - re-aligns board between puzzle and gameplay modes

### Caveats:
 - Does change existing layout for streamers relying on the current layout
 - Gets rid of the score box (took up vertical space and was causing scrolling issues)
 - Most changes are not applied to narrower layouts (between 800 and 1200px wide)

### Comparison: 
Before:
<img src="https://user-images.githubusercontent.com/974758/218640211-726b426c-2cf9-440d-9157-beb6d7b9dc5c.png" width=320 />

After:
<img src="https://user-images.githubusercontent.com/974758/218640216-8a5cb082-f3f2-4bc9-959e-09e3a38ffea3.png" width=320 />

### Technical Notes:
 - Bumps version number to 1.1.2 instead of 1.1.1, due 1.1.1 being committed to this repo, then rolled back.