### PR TITLE
Revert "Don't fix zoom to 95%"

### DIFF
--- a/lichess.streamer.user.css
+++ b/lichess.streamer.user.css
@@ -34,6 +34,7 @@ body.dark { background: #161512; }
     /* Remove 2vmin bottom margin */
     margin: 0px;
     padding: 0px;
+    --zoom: 95 !important;
   }
 
   /* Make clocks bigger */


### PR DESCRIPTION
This reverts commit 2aa3567f74097a12034d50451651c48b996d0f01.

Commit introduces a zoom issue, causing the bottom of the clock to be cut off.

![Screenshot_2023-03-04_22-01-47](https://user-images.githubusercontent.com/974758/222939412-a0406953-9042-4bd8-84dd-91c5e3e5c267.png)
