### PR TITLE
Add margin-bottom

### DIFF
--- a/lichess.streamer.user.css
+++ b/lichess.streamer.user.css
@@ -94,6 +94,7 @@ body.dark { background: #161512; }
     grid-template-rows: 30px 1fr auto min-content auto auto min-content auto 1fr 30px;
     grid-template-areas: 'user-top .' 'board .' 'board mat-top'  'board expi-top'  'board moves'  'board controls'  'board expi-bot'  'board mat-bot' 'board .'  'user-bot .'  'kb-move .';
     margin-top: .2em;
+    margin-bottom: -.5em;
   }
   .round__app .rclock-top, .round__app .rclock-bottom {
     grid-area: 1 / 1 / 2 / 2;


### PR DESCRIPTION
Seems the `margin-top` change in #12 caused the info below the board to become obscured.
This Pull Request adds a `margin-bottom` to get some space between board and info...

Relates: #12 / a924a75

![without](https://github.com/ornicar/userstyles/assets/4084220/f22a8304-6ed8-44c0-a804-cb62b1ad193a)
![with](https://github.com/ornicar/userstyles/assets/4084220/a83336f3-723c-4e73-8a5f-7b18c77a2d93)
